### PR TITLE
Add support for address being either an address or a variable.

### DIFF
--- a/MemoryPanel.cpp
+++ b/MemoryPanel.cpp
@@ -178,14 +178,14 @@ void MemoryPanel::UpdatePanel()
         ascii  << wxString::Format("%#10llx ", llAddress); // 10 = 0x + 8 digits
     }
 
-    bool bGDBOldMemoryRead = val.Contains("0x");
     wxCharBuffer buff = val.To8BitData();
     wxString hBuff;
     long lBuff;
+    size_t valSize = val.size();
 
-    for(size_t i = 0; i < val.size(); ++i)
+    for(size_t i = 0; i < valSize; ++i)
     {
-        if (bGDBOldMemoryRead)
+        if (valSize == m_llSize)
         {
             lBuff = buff[i];
             memory << wxString::Format("%02x ",(unsigned int)(0xFF&lBuff));
@@ -213,7 +213,7 @@ void MemoryPanel::UpdatePanel()
             ascii << wxString::Format("·· ");
         }
 
-        if((i+1) % 32 == 0)
+        if (((i+1) % 32 == 0) && (i < valSize-1))
         {
             uint64_t m_llAddressDisplay = llAddress + line * 32;
 #if wxCHECK_VERSION(3, 1, 5)

--- a/MemoryPanel.h
+++ b/MemoryPanel.h
@@ -45,7 +45,7 @@ class MemoryPanel: public wxPanel
 		void OnTextEnter(wxCommandEvent& event);
 		//*)
 
-		uint64_t                 m_addr;
+        wxString m_sAddress;
 		std::shared_ptr<cbWatch> m_watch;
 
 		DECLARE_EVENT_TABLE()

--- a/MemoryPanel.h
+++ b/MemoryPanel.h
@@ -46,6 +46,7 @@ class MemoryPanel: public wxPanel
 		//*)
 
         wxString m_sAddress;
+        uint64_t m_llSize;
 		std::shared_ptr<cbWatch> m_watch;
 
 		DECLARE_EVENT_TABLE()

--- a/MemoryPanel.xrc
+++ b/MemoryPanel.xrc
@@ -11,7 +11,7 @@
 					<cols>4</cols>
 					<growablecols>1</growablecols>
 					<object class="sizeritem">
-						<object class="wxStaticText" name="ID_STATICTEXT1">
+						<object class="wxStaticText" name="ID_STATICTEXT_ADDRESS">
 							<label>Address:</label>
 						</object>
 						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
@@ -19,7 +19,7 @@
 						<option>1</option>
 					</object>
 					<object class="sizeritem">
-						<object class="wxTextCtrl" name="ID_TEXTCTRL1">
+						<object class="wxTextCtrl" name="ID_TEXTCTRL_ADDRESS">
 							<value>0x0</value>
 							<style>wxTE_PROCESS_ENTER</style>
 						</object>
@@ -28,7 +28,7 @@
 						<option>3</option>
 					</object>
 					<object class="sizeritem">
-						<object class="wxStaticText" name="ID_STATICTEXT2">
+						<object class="wxStaticText" name="ID_STATICTEXT_SIZE">
 							<label>Size:</label>
 						</object>
 						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
@@ -36,7 +36,7 @@
 						<option>1</option>
 					</object>
 					<object class="sizeritem">
-						<object class="wxTextCtrl" name="ID_TEXTCTRL2">
+						<object class="wxTextCtrl" name="ID_TEXTCTRL_SIZE">
 							<value>32</value>
 							<style>wxTE_PROCESS_ENTER</style>
 						</object>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <CodeBlocks_plugin_manifest_file>
-    <SdkVersion major="1" minor="36"  release="0" />
+    <SdkVersion major="2" minor="17"  release="0" />
     <Plugin name="cbMemoryView">
         <Value title="cbMemoryView" />
-        <Value version="0.1" />
+        <Value version="0.2.0" />
         <Value description="" />
         <Value author="Bluehazzard" />
         <Value authorEmail="bluehazzard2@gmail.com" />
-        <Value authorWebsite="" />
+        <Value authorWebsite="https://github.com/bluehazzard/cbMemoryView" />
         <Value thanksTo="" />
         <Value license="GPL" />
     </Plugin>


### PR DESCRIPTION
DO not merge this without fixing the UpdatePanel() function so it works with the existing GDB plugin.

This works with the GDB/MI plugin as the low level GDB command used to get the memory returns a string, which is what I have modified the UpdatePanel() to use, but the existing GDB plugin uses an array of hex bytes.